### PR TITLE
use_sf(), use_sp(): unambiguous error messages

### DIFF
--- a/R/rgrass.R
+++ b/R/rgrass.R
@@ -171,12 +171,12 @@ use_sf <- function() {
   if (requireNamespace("sf", quietly=TRUE) && 
     requireNamespace("stars", quietly=TRUE))
     assign("R_interface", "sf", envir=.GRASS_CACHE)
-  else stop("sf or stars not available")
+  else stop("sf or stars is not available. You need both packages installed.")
 }
 
 use_sp <- function() {
   if (requireNamespace("sp", quietly=TRUE) && 
      requireNamespace("rgdal", quietly=TRUE))
      assign("R_interface", "sp", envir=.GRASS_CACHE)
-  else stop("sp or rgdal not available")
+  else stop("sp or rgdal is not available. You need both packages installed.")
 }


### PR DESCRIPTION
In a fresh R installation, with `sf` installed but not (yet) `stars`, I got following eror when rerunning a script:

```r
> library(rgrass7)
Loading required package: XML
GRASS GIS interface loaded with GRASS version: (GRASS not running)
> use_sf()
Error in use_sf() : sf or stars not available
```

I was a bit puzzled because I had `sf` installed, so 'sf or stars' _is_ available :smiley_cat: . From the discussion in #10 I got the point, so here's a suggestion to make the error messages a little less ambiguous. Of course refine them if you like.

Thanks for all your nice work.