### PR TITLE
Adding new function to pass a full GRASS statement (including flags and parameters)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 oChangeLog
 README
 docs
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.Rdata
+.httr-oauth
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .Rdata
 .httr-oauth
 .DS_Store
+*.Rproj

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,7 +6,7 @@ importFrom(stats, runif, na.omit)
 importFrom(methods, slot, "slot<-", as)
 
 export(gmeta, getLocationProj, gmeta2grd)
-export(execGRASS, doGRASS, parseGRASS, getXMLencoding, setXMLencoding)
+export(execGRASS, stringexecGRASS, doGRASS, parseGRASS, getXMLencoding, setXMLencoding)
 export(initGRASS, get.GIS_LOCK, set.GIS_LOCK, unset.GIS_LOCK, unlink_.gislock)
 export(remove_GISRC)
 export(readRAST, writeRAST)

--- a/R/xml1.R
+++ b/R/xml1.R
@@ -459,8 +459,8 @@ stringexecGRASS <- function(string,
                                         simple_params, 
                                         perl = TRUE))
     simple_params <- as.list(simple_params)
-    simple_params[grep("^[0-9]+$", simple_params)] <- 
-      as.numeric(simple_params[grep("^[0-9]+$", simple_params)])
+    simple_params[grep("^[+-]?(\\d*\\.)?\\d+$", simple_params)] <- 
+      as.numeric(simple_params[grep("^[+-]?(\\d*\\.)?\\d+$", simple_params)])
   }
   # combine simple and quoted parameters
   if (length(simple_params) > 0 || length(quoted_params) > 0) {

--- a/R/xml1.R
+++ b/R/xml1.R
@@ -411,4 +411,91 @@ execGRASS <- function(cmd, flags=NULL, ..., parameters=NULL, intern=NULL,
     invisible(res)
 }
 
+stringexecGRASS <- function(string, 
+                            intern=NULL,
+                            ignore.stderr=NULL, 
+                            Sys_ignore.stdout=FALSE, 
+                            Sys_wait=TRUE,
+                            Sys_input=NULL, 
+                            Sys_show.output.on.console=TRUE, 
+                            Sys_minimized=FALSE,
+                            Sys_invisible=TRUE, 
+                            echoCmd=NULL, 
+                            redirect=FALSE, 
+                            legacyExec=NULL) {
+  stopifnot(is.character(string) && length(string) == 1)
+  # extract quoted parameters
+  quoted_params <- regmatches(string, 
+                              gregexpr("\\w+=['\"].*?['\"]", string))[[1]]
+  if (length(quoted_params) > 0) {
+    names(quoted_params) <- regmatches(quoted_params, 
+                                       regexpr("^\\w+", quoted_params))
+    quoted_params <- regmatches(quoted_params, 
+                                regexpr("(?<==['\"]).+(?=['\"]$)", 
+                                        quoted_params, 
+                                        perl = TRUE))
+    quoted_params <- as.list(quoted_params)
+  }
+  # split remaining parts into cmd, flags and simple parameters
+  components <- strsplit(gsub("\\w+=['\"].*?['\"]", "", string), "\\s+")[[1]]
+  cmd <- components[1]
+  if (!grepl("^\\w{1,2}\\.\\w+\\.*\\w*\\.*\\w*\\.*\\w*$", cmd)) {
+    stop("The string argument of stringexecGRASS() ",
+         "must begin with a valid GRASS command name.")
+  }
+  pattern_flag <- "^-+"
+  flags <- grep(pattern_flag, components, value = TRUE)
+  if (length(flags) > 0) {
+    flags <- sub(pattern_flag, "", flags)
+    } else {
+    flags <- NULL
+  }
+  simple_params <- grep("^\\w+=", components, value = TRUE)
+  if (length(simple_params) > 0) {
+    names(simple_params) <- regmatches(simple_params, 
+                                       regexpr("^\\w+", simple_params))
+    simple_params <- regmatches(simple_params, 
+                                regexpr("(?<==).+$", 
+                                        simple_params, 
+                                        perl = TRUE))
+    simple_params <- as.list(simple_params)
+    simple_params[grep("^[0-9]+$", simple_params)] <- 
+      as.numeric(simple_params[grep("^[0-9]+$", simple_params)])
+  }
+  # combine simple and quoted parameters
+  if (length(simple_params) > 0 || length(quoted_params) > 0) {
+    parameters <- c(simple_params, quoted_params)
+  } else {
+    parameters <- NULL
+  }
+  # non-processed parts of 'components' will lead to an error
+  if (length(flags) + length(parameters) + 1 != 
+      length(components) + length(quoted_params)) {
+    stop("stringexecGRASS() could not successfully split the provided string ",
+         "into ONE command name plus (optionally) flags and parameters.\n",
+         "Please check syntax:\n",
+         "- the command name, flags and parameters must be separated by ",
+         "a whitespace\n",
+         "- each parameter must be of the form key=value; ",
+         "if 'value' contains spaces, then 'value' must be quoted\n",
+         "- concatenation of flags (as in 'g.proj -wf') is not supported: ",
+         "use 'g.proj -w -f'\n",
+         "- the command name must come at the beginning\n")
+  }
+  execGRASS(cmd = cmd, 
+            flags=flags, 
+            parameters=parameters, 
+            intern=intern,
+            ignore.stderr=ignore.stderr,
+            Sys_ignore.stdout=Sys_ignore.stdout,
+            Sys_wait=Sys_wait,
+            Sys_input=Sys_input,
+            Sys_show.output.on.console=Sys_show.output.on.console,
+            Sys_minimized=Sys_minimized,
+            Sys_invisible=Sys_invisible,
+            echoCmd=echoCmd,
+            redirect=redirect,
+            legacyExec=legacyExec)
+}
+
 

--- a/man/execGRASS.Rd
+++ b/man/execGRASS.Rd
@@ -1,5 +1,6 @@
 \name{execGRASS}
 \alias{execGRASS}
+\alias{stringexecGRASS}
 \alias{doGRASS}
 \alias{parseGRASS}
 \alias{getXMLencoding}
@@ -12,6 +13,10 @@
 }
 \usage{
 execGRASS(cmd, flags = NULL, ..., parameters = NULL, intern = NULL,
+ ignore.stderr = NULL, Sys_ignore.stdout=FALSE, Sys_wait=TRUE,
+ Sys_input=NULL, Sys_show.output.on.console=TRUE, Sys_minimized=FALSE,
+ Sys_invisible=TRUE, echoCmd=NULL, redirect=FALSE, legacyExec=NULL)
+stringexecGRASS(string, intern = NULL,
  ignore.stderr = NULL, Sys_ignore.stdout=FALSE, Sys_wait=TRUE,
  Sys_input=NULL, Sys_show.output.on.console=TRUE, Sys_minimized=FALSE,
  Sys_invisible=TRUE, echoCmd=NULL, redirect=FALSE, legacyExec=NULL)
@@ -28,6 +33,8 @@ setXMLencoding(enc)
   \item{flags}{character vector of GRASS command flags}
   \item{...}{for \code{execGRASS} and \code{doGRASS}, GRASS module parameters given as R named arguments directly. For the \code{print} method, other arguments to print method. The storage modes of values passed must match thos required in GRASS, so a single GRASS string must be a character vector of length 1, a single GRASS integer must be an integer vector of length 1 (may be an integer constant such as 10L), and a single GRASS float must be a numeric vector of length 1. For multiple values, use vectors of suitable length}
   \item{parameters}{list of GRASS command parameters, used if GRASS parameters are not given as R arguments directly; the two methods for passing GRASS parameters may not be mixed. The storage modes of values passed must match thos required in GRASS, so a single GRASS string must be a character vector of length 1, a single GRASS integer must be an integer vector of length 1 (may be an integer constant such as 10L), and a single GRASS float must be a numeric vector of length 1. For multiple values, use vectors of suitable length}
+  \item{string}{a string representing \emph{one} full GRASS statement, using shell syntax: command name, optionally followed by flags and parameters, all separated by whitespaces.
+  Parameters follow the key=value format; if 'value' contains spaces, then 'value' must be quoted}
   \item{intern}{default NULL, in which case set internally from \code{get.useInternOption}; a logical (not 'NA') which indicates whether to make the output of the command an R object. Not available unless 'popen' is supported on the platform}
   \item{ignore.stderr}{default NULL, taking the value set by \code{set.ignore.stderrOption}, a logical indicating whether error messages written to 'stderr' should be ignored}
   \item{Sys_ignore.stdout, Sys_wait, Sys_input}{pass extra arguments to \code{system}}
@@ -40,9 +47,13 @@ setXMLencoding(enc)
 }
 \details{
   \code{parseGRASS} checks to see whether the GRASS command has been parsed already and cached in this session; if not, it reads the interface description, parses it and caches it for future use. \code{doGRASS} assembles a proposed GRASS command with flags and parameters as a string, wrapping \code{parseGRASS}, and \code{execGRASS} is a wrapper for \code{doGRASS}, running the command through \code{system} (from 0.7-4, the \code{...} argument is not used for passing extra arguments for \code{system}). The command string is termed proposed, because not all of the particular needs of commands are provided by the interface description, and no check is made for the existence of input objects. Support for multiple parameter values added with help from Patrick Caldon. Support for defaults and for direct use of GRASS parameters instead of a parameter list suggested by Rainer Krug.
+  
+  \code{stringexecGRASS} is a wrapper around \code{execGRASS}, and accepts a single shell statement as a string (following GRASS's command syntax).
 }
+
 \value{
-  \code{parseGRASS} returns a \code{GRASS_interface_desc} object, \code{doGRASS} returns a character string with a proposed GRASS command - the expanded command name is returned as an attribute, and \code{execGRASS} returns what \code{system} or \code{system2} return, particularly depending on the \code{intern} argument when the character strings output by GRASS modules are returned. If \code{intern} is \code{FALSE}, \code{system} returns the module exit code, while \code{system2} returns the module exit code with \dQuote{resOut} and \dQuote{resErr} attributes.}
+  \code{parseGRASS} returns a \code{GRASS_interface_desc} object, \code{doGRASS} returns a character string with a proposed GRASS command - the expanded command name is returned as an attribute, and \code{execGRASS} and  \code{stringexecGRASS} return what \code{system} or \code{system2} return, particularly depending on the \code{intern} argument when the character strings output by GRASS modules are returned.
+  If \code{intern} is \code{FALSE}, \code{system} returns the module exit code, while \code{system2} returns the module exit code with \dQuote{resOut} and \dQuote{resErr} attributes.}
 
 
 \note{If any package command fails with a UTF-8 error from the XML package, try using \code{setXMLencoding} to work around the problem that GRASS modules declare --interface-description output as UTF-8 without ensuring that it is (French is of 6.4.0 RC5 latin1).}
@@ -95,6 +106,12 @@ if (run) {
       flags = c("C", "n"), redirect=TRUE, legacyExec=TRUE)
     print(resERR)
   }
+}
+if (run) {
+  stringexecGRASS("g.manual entry=r.stats")
+  res <- stringexecGRASS("r.stats input=fire_blocksgg -C -n",
+    legacyExec=TRUE)
+  print(res)
 }
 }
 % Add one or more standard keywords, see file 'KEYWORDS' in the


### PR DESCRIPTION
The proposed function is a wrapper around `execGRASS()` and accepts a single shell statement as a string, following GRASS's command syntax. Compared to `execGRASS()`, the arguments `cmd`, `flags`, `...` and `parameters` are replaced by a single argument `string`; all other arguments have been kept.

Please review carefully. I did some testing in Linux but maybe cases still exist that are not accounted for. The function name `stringexecGRASS()` is open to discussion.

This PR is an attempt to fix #17.

Examples:

``` r
library(rgrass7)
#> Loading required package: XML
#> GRASS GIS interface loaded with GRASS version: (GRASS not running)
link2GI::findGRASS()
#>            instDir version installation_type
#> 1 /usr/lib/grass78   7.8.5           grass78
initGRASS(gisBase = link2GI::findGRASS()[1, "instDir"], 
          home = tempdir(),
          mapset = "PERMANENT")
#> gisdbase    /tmp/RtmpVrpIfK 
#> location    file218d65a77c78 
#> mapset      PERMANENT 
#> rows        1 
#> columns     1 
#> north       1 
#> south       0 
#> west        0 
#> east        1 
#> nsres       1 
#> ewres       1 
#> projection:
#>  XY location (unprojected)
stringexecGRASS("g.proj epsg=31370") # verbose output on error
#> Error in execGRASS(cmd = cmd, flags = flags, parameters = parameters, : The command:
#> g.proj epsg=31370
#> produced an error (1) during execution:
#> ERROR: No output format specified, define one of flags -p, -g, -j, or -w
stringexecGRASS("g.proj -w -f epsg=31370")
#> PROJCS["Belge 1972 / Belgian Lambert 72",GEOGCS["Belge 1972",DATUM["Reseau_National_Belge_1972",SPHEROID["International 1924",6378388,297,AUTHORITY["EPSG","7022"]],TOWGS84[-99.059,53.322,-112.486,0.419,-0.83,1.885,-1],AUTHORITY["EPSG","6313"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4313"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["latitude_of_origin",90],PARAMETER["central_meridian",4.36748666666667],PARAMETER["standard_parallel_1",51.1666672333333],PARAMETER["standard_parallel_2",49.8333339],PARAMETER["false_easting",150000.013],PARAMETER["false_northing",5400088.438],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","31370"]]
stringexecGRASS("g.proj -w -f epsg=31370", intern = TRUE)
#> [1] "PROJCS[\"Belge 1972 / Belgian Lambert 72\",GEOGCS[\"Belge 1972\",DATUM[\"Reseau_National_Belge_1972\",SPHEROID[\"International 1924\",6378388,297,AUTHORITY[\"EPSG\",\"7022\"]],TOWGS84[-99.059,53.322,-112.486,0.419,-0.83,1.885,-1],AUTHORITY[\"EPSG\",\"6313\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4313\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",90],PARAMETER[\"central_meridian\",4.36748666666667],PARAMETER[\"standard_parallel_1\",51.1666672333333],PARAMETER[\"standard_parallel_2\",49.8333339],PARAMETER[\"false_easting\",150000.013],PARAMETER[\"false_northing\",5400088.438],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"31370\"]]"
stringexecGRASS("g.manual entry=g.proj")
stringexecGRASS("g.proj -c georef=/vsicurl/https://download.osgeo.org/geotiff/samples/made_up/bogota.tif")
#> Default region was updated to the new projection, but if you have multiple
#> mapsets `g.region -d` should be run in each to update the region from the
#> default
#> Projection information updated
stringexecGRASS("r.in.gdal input=/vsicurl/https://download.osgeo.org/geotiff/samples/made_up/bogota.tif output=bogota memory=2000")
#> Importing raster map <bogota>...
#>    0%   3%   6%   9%  12%  15%  18%  21%  24%  27%  30%  33%  36%  39%  42%  45%  48%  51%  54%  57%  60%  63%  66%  69%  72%  75%  78%  81%  84%  87%  90%  93%  96%  99% 100%
stringexecGRASS("g.region raster=bogota -p")
#> projection: 99 (Bogota 1975 / Colombia Bogota zone)
#> zone:       0
#> datum:      towgs84=307,304,-318,0,0,0,0
#> ellipsoid:  international
#> north:      100000
#> south:      69280
#> west:       440720
#> east:       471440
#> nsres:      60
#> ewres:      60
#> rows:       512
#> cols:       512
#> cells:      262144
```

<sup>Created on 2020-12-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 4.0.3 (2020-10-10)
#>  os       Linux Mint 19               
#>  system   x86_64, linux-gnu           
#>  ui       X11                         
#>  language nl_BE:nl                    
#>  collate  nl_BE.UTF-8                 
#>  ctype    nl_BE.UTF-8                 
#>  tz       Europe/Brussels             
#>  date     2020-12-30                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version  date       lib source                            
#>  assertthat    0.2.1    2019-03-21 [1] CRAN (R 4.0.3)                    
#>  callr         3.5.1    2020-10-13 [1] CRAN (R 4.0.3)                    
#>  class         7.3-17   2020-04-26 [4] CRAN (R 4.0.0)                    
#>  classInt      0.4-3    2020-04-07 [1] CRAN (R 4.0.3)                    
#>  cli           2.2.0    2020-11-20 [1] CRAN (R 4.0.3)                    
#>  crayon        1.3.4    2017-09-16 [1] CRAN (R 4.0.3)                    
#>  DBI           1.1.0    2019-12-15 [1] CRAN (R 4.0.3)                    
#>  desc          1.2.0    2018-05-01 [1] CRAN (R 4.0.3)                    
#>  devtools      2.3.2    2020-09-18 [1] CRAN (R 4.0.3)                    
#>  digest        0.6.27   2020-10-24 [1] CRAN (R 4.0.3)                    
#>  dplyr         1.0.2    2020-08-18 [1] CRAN (R 4.0.3)                    
#>  e1071         1.7-4    2020-10-14 [1] CRAN (R 4.0.3)                    
#>  ellipsis      0.3.1    2020-05-15 [1] CRAN (R 4.0.3)                    
#>  evaluate      0.14     2019-05-28 [1] CRAN (R 4.0.3)                    
#>  fansi         0.4.1    2020-01-08 [1] CRAN (R 4.0.3)                    
#>  fs            1.5.0    2020-07-31 [1] CRAN (R 4.0.3)                    
#>  generics      0.1.0    2020-10-31 [1] CRAN (R 4.0.3)                    
#>  glue          1.4.2    2020-08-27 [1] CRAN (R 4.0.3)                    
#>  highr         0.8      2019-03-20 [1] CRAN (R 4.0.3)                    
#>  htmltools     0.5.0    2020-06-16 [1] CRAN (R 4.0.3)                    
#>  KernSmooth    2.23-18  2020-10-29 [4] CRAN (R 4.0.3)                    
#>  knitr         1.30     2020-09-22 [1] CRAN (R 4.0.3)                    
#>  lifecycle     0.2.0    2020-03-06 [1] CRAN (R 4.0.3)                    
#>  link2GI       0.4-6    2020-12-30 [1] Github (r-spatial/link2GI@1049705)
#>  magrittr      2.0.1    2020-11-17 [1] CRAN (R 4.0.3)                    
#>  memoise       1.1.0    2017-04-21 [1] CRAN (R 4.0.3)                    
#>  pillar        1.4.7    2020-11-20 [1] CRAN (R 4.0.3)                    
#>  pkgbuild      1.2.0    2020-12-15 [1] CRAN (R 4.0.3)                    
#>  pkgconfig     2.0.3    2019-09-22 [1] CRAN (R 4.0.3)                    
#>  pkgload       1.1.0    2020-05-29 [1] CRAN (R 4.0.3)                    
#>  prettyunits   1.1.1    2020-01-24 [1] CRAN (R 4.0.3)                    
#>  processx      3.4.5    2020-11-30 [1] CRAN (R 4.0.3)                    
#>  ps            1.5.0    2020-12-05 [1] CRAN (R 4.0.3)                    
#>  purrr         0.3.4    2020-04-17 [1] CRAN (R 4.0.3)                    
#>  R6            2.5.0    2020-10-28 [1] CRAN (R 4.0.3)                    
#>  Rcpp          1.0.5    2020-07-06 [1] CRAN (R 4.0.3)                    
#>  remotes       2.2.0    2020-07-21 [1] CRAN (R 4.0.3)                    
#>  rgrass7     * 0.2-3    2020-12-30 [1] local                             
#>  rlang         0.4.9    2020-11-26 [1] CRAN (R 4.0.3)                    
#>  rmarkdown     2.6      2020-12-14 [1] CRAN (R 4.0.3)                    
#>  roxygen2      7.1.1    2020-06-27 [1] CRAN (R 4.0.3)                    
#>  rprojroot     2.0.2    2020-11-15 [1] CRAN (R 4.0.3)                    
#>  sessioninfo   1.1.1    2018-11-05 [1] CRAN (R 4.0.3)                    
#>  sf            0.9-6    2020-09-13 [1] CRAN (R 4.0.3)                    
#>  stringi       1.5.3    2020-09-09 [1] CRAN (R 4.0.3)                    
#>  stringr       1.4.0    2019-02-10 [1] CRAN (R 4.0.3)                    
#>  testthat      3.0.1    2020-12-17 [1] CRAN (R 4.0.3)                    
#>  tibble        3.0.4    2020-10-12 [1] CRAN (R 4.0.3)                    
#>  tidyselect    1.1.0    2020-05-11 [1] CRAN (R 4.0.3)                    
#>  units         0.6-7    2020-06-13 [1] CRAN (R 4.0.3)                    
#>  usethis       2.0.0    2020-12-10 [1] CRAN (R 4.0.3)                    
#>  vctrs         0.3.6    2020-12-17 [1] CRAN (R 4.0.3)                    
#>  withr         2.3.0    2020-09-22 [1] CRAN (R 4.0.3)                    
#>  xfun          0.19     2020-10-30 [1] CRAN (R 4.0.3)                    
#>  XML         * 3.99-0.5 2020-07-23 [1] CRAN (R 4.0.3)                    
#>  xml2          1.3.2    2020-04-23 [1] CRAN (R 4.0.3)                    
#>  yaml          2.2.1    2020-02-01 [1] CRAN (R 4.0.3)                    
#> 
#> [1] /home/floris/lib/R/library
#> [2] /usr/local/lib/R/site-library
#> [3] /usr/lib/R/site-library
#> [4] /usr/lib/R/library
```

</details>