### PR TITLE
fix issue where readRAST fails with grass >=7.6

### DIFF
--- a/R/bin_link.R
+++ b/R/bin_link.R
@@ -66,7 +66,7 @@ readRAST <- function(vname, cat=NULL, ignore.stderr=get.ignore.stderrOption(),
 
 	if (!R_in_sp) stop("no stars import yet")
         
-	p4 <- sp::CRS(getLocationProj())
+	p4 <- sp::CRS(getLocationProj(g.proj_WKT=FALSE))
 
         reslist <- vector(mode="list", length=length(vname))
         names(reslist) <- vname


### PR DESCRIPTION
The most recent version changes to reading WKT projections from grass by default with grass >= 7.6, which is not working for rasters. I was getting `no arguments in initialization list` whenever I tried to read a raster.

This seemed like a simple fix, so I just did it myself rather than creating an issue, but happy for feedback if this is somehow breaking something.